### PR TITLE
Add encoding and decoding support for following types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ mvn assembly:single
 ```
 This could take around 5 minutes.
 
-Pebble API Description
-----------------------
-The current implementation supports the compression and decompression of lists of positive integer. These lists
-can be of three types: **strictly incremental lists**, **incremental lists** and **unsorted lists**. For details
+Pebble Core API Description
+---------------------------
+The current implementation supports the compression and decompression of lists of positive integers and longs. These
+lists can be of three types: **strictly incremental lists**, **incremental lists** and **unsorted lists**. For details
 regarding the library api, refer to the
 [Api Documentation](//groupon.github.io/pebble/index.html).
 On following sections the basics around encoding and decoding lists is explained.
@@ -168,15 +168,3 @@ while (iterator.hasNext()) {
     System.out.println(iterator.nextInt());
 }
 ```
-
-TODO
-----
-* Add support for lists of `long` type.
-* Add support for storing more than integer values, such as: uuids, timestamps, finite text, free text and real numbers.
-* Explore the usage of [Trove](http://trove.starlight-systems.com/) library instead of
-  [FastUtils WebGraph](http://fastutil.di.unimi.it/) library.
-* Add support for storing complex data types. Data that is build on top primitive data types.
-* Implement java.util.Map interface.
-* Explore hbase memory cache.
-* Explore hadoop files storage application.
-* Use same compressed list as the reference list buffer. This will be helpful as well, to update the store on real time.

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.pebble</groupId>
     <artifactId>pebble-core</artifactId>
-    <version>1.2.0</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/org/pebble/core/PebbleBytesStore.java
+++ b/src/main/java/org/pebble/core/PebbleBytesStore.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -15,6 +13,8 @@ package org.pebble.core.decoding;
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+package org.pebble.core;
 
 import it.unimi.dsi.io.InputBitStream;
 
@@ -45,13 +45,13 @@ public abstract class PebbleBytesStore {
      * @param listIndex index of list.
      * @return byte array which contains the data of the compressed list associated with <code>listIndex</code>.
      */
-    protected abstract byte[] get(int listIndex);
+    protected abstract byte[] get(final int listIndex);
 
     /**
      * Gets the offset in bits where the compressed list associated with <code>listIndex</code> starts.
      * @param listIndex index of list.
      * @return the offset in bits where the compressed list associated with <code>listIndex</code> starts.
      */
-    protected abstract long offset(int listIndex);
+    protected abstract long offset(final int listIndex);
 
 }

--- a/src/main/java/org/pebble/core/PebbleOffsetsStore.java
+++ b/src/main/java/org/pebble/core/PebbleOffsetsStore.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.core;
+
+/**
+ * Interface used to access the mapping between an entry and the starting offset in bits of its encoded representation.
+ */
+public interface PebbleOffsetsStore {
+
+    /**
+     * Returns the offset of the start of the encoded representation of <code>index</code>-th entry.
+     * @param index of entry.
+     * @return offset in bits of the start of the encoded representation of <code>index</code>-th entry.
+     */
+    public long get(int index);
+
+}

--- a/src/main/java/org/pebble/core/PebbleOffsetsStoreWriter.java
+++ b/src/main/java/org/pebble/core/PebbleOffsetsStoreWriter.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.core;
+
+import java.io.IOException;
+
+/**
+ * Interface used to update the mapping between an entry and the starting offset in bits of its encoded representation.
+ */
+public interface PebbleOffsetsStoreWriter {
+
+    /**
+     * Appends to offsets store the offset of latest entry encoded representation.
+     *
+     * @param offset in bits of the starting offset of latest encoded entry representation.
+     * @throws IOException in case there is an exception appending <code>offset</code> to the store.
+     */
+    public void append(long offset) throws IOException;
+
+}

--- a/src/main/java/org/pebble/core/decoding/iterators/ints/BaseListIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/ints/BaseListIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,9 +14,11 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 
@@ -128,7 +128,7 @@ abstract class BaseListIterator implements IntIterator {
      */
     @Override
     public Integer next() {
-        int value = nextInt();
+        final int value = nextInt();
         return value == -1 ? null : value;
     }
 

--- a/src/main/java/org/pebble/core/decoding/iterators/ints/IncrementalListIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/ints/IncrementalListIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,11 +14,14 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
-import org.pebble.core.encoding.DefaultParametersValues;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
+
+import static org.pebble.core.encoding.DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE;
 
 /**
  * Iterator over a compressed incremental list of <code>int</code>s. See
@@ -85,12 +86,32 @@ public class IncrementalListIterator extends IncrementalListUniqueIterator {
         final PebbleBytesStore bytesStore
     ) throws IOException {
         final InputBitStream inputBitStream = bytesStore.getInputBitStream(listIndex);
-        RepeatsIterator repeatsIterator = new RepeatsIterator(inputBitStream);
+        return build(listIndex, valueBitSize, bytesStore, inputBitStream);
+    }
+
+    /**
+     * Instance builder.
+     * @param listIndex index of the current list.
+     * @param valueBitSize fixed number of bits used to represent value in list to be encoded. It can be any value
+     *                     between 1bit and 31 bits.
+     * @param bytesStore mapping between list offsets and data bytes arrays and bytes offsets.
+     * @param inputBitStream input bit stream used to read the compressed lists representations. The cursor must be
+     *                       positioned at the beginning of encoding.
+     * @return built instance.
+     * @throws IOException when there is an exception reading from <code>inputBitStream</code>.
+     */
+    public static IncrementalListIterator build(
+        final int listIndex,
+        final int valueBitSize,
+        final PebbleBytesStore bytesStore,
+        final InputBitStream inputBitStream
+    ) throws IOException {
+        final RepeatsIterator repeatsIterator = new RepeatsIterator(inputBitStream);
         inputBitStream.skipDeltas(repeatsIterator.getRemainingElements() * 2);
         return new IncrementalListIterator(
             listIndex,
             valueBitSize,
-            DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE,
+            DEFAULT_MIN_INTERVAL_SIZE,
             inputBitStream,
             bytesStore,
             repeatsIterator

--- a/src/main/java/org/pebble/core/decoding/iterators/ints/IncrementalListUniqueIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/ints/IncrementalListUniqueIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,8 +14,10 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 
@@ -73,7 +73,7 @@ class IncrementalListUniqueIterator extends BaseListIterator {
         final InputBitStream inputBitStream,
         final PebbleBytesStore bytesStore
     ) throws IOException {
-        RepeatsIterator repeatsIterator = new RepeatsIterator(inputBitStream);
+        final RepeatsIterator repeatsIterator = new RepeatsIterator(inputBitStream);
         inputBitStream.skipDeltas(repeatsIterator.getRemainingElements() * 2);
         return new IncrementalListUniqueIterator(listIndex, valueBitSize, minIntervalSize, inputBitStream, bytesStore);
     }

--- a/src/main/java/org/pebble/core/decoding/iterators/ints/IncrementalReferenceUniqueIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/ints/IncrementalReferenceUniqueIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,9 +14,11 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 

--- a/src/main/java/org/pebble/core/decoding/iterators/ints/ListIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/ints/ListIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,13 +14,16 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
-import org.pebble.core.encoding.DefaultParametersValues;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
+
+import static org.pebble.core.encoding.DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE;
 
 /**
  * Iterator over a compressed list of <code>int</code>s. See
@@ -66,9 +67,9 @@ public class ListIterator extends StrictlyIncrementalListIterator {
                 index = inputBitStream.readDelta();
                 if ((index & 1) == 0) {
                     lastIndex = index / 2 + lastIndex;
-                    return valuesMap.get(lastIndex);
+                } else {
+                    lastIndex = lastIndex - (index + 1) / 2;
                 }
-                lastIndex = lastIndex - (index + 1) / 2;
                 return valuesMap.get(lastIndex);
             }
         } catch (IOException e) {
@@ -99,13 +100,27 @@ public class ListIterator extends StrictlyIncrementalListIterator {
         final int valueBitSize,
         final PebbleBytesStore bytesStore
     ) throws IOException {
-        return new ListIterator(
-            listIndex,
-            valueBitSize,
-            DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE,
-            bytesStore.getInputBitStream(listIndex),
-            bytesStore
-        );
+        return build(listIndex, valueBitSize, bytesStore, bytesStore.getInputBitStream(listIndex));
+    }
+
+    /**
+     * Instance builder.
+     * @param listIndex index of the current list.
+     * @param valueBitSize fixed number of bits used to represent value in list to be encoded. It can be any value
+     *                     between 1bit and 31 bits.
+     * @param inputBitStream input bit stream used to read the compressed lists representations. The cursor must be
+     *                       positioned at the beginning of encoding.
+     * @param bytesStore mapping between list offsets and data bytes arrays and bytes offsets.
+     * @return built instance.
+     * @throws IOException when there is an exception reading from <code>inputBitStream</code>.
+     */
+    public static ListIterator build(
+        final int listIndex,
+        final int valueBitSize,
+        final PebbleBytesStore bytesStore,
+        final InputBitStream inputBitStream
+    ) throws IOException {
+        return new ListIterator(listIndex, valueBitSize, DEFAULT_MIN_INTERVAL_SIZE, inputBitStream, bytesStore);
     }
 
 }

--- a/src/main/java/org/pebble/core/decoding/iterators/ints/ReferenceIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/ints/ReferenceIterator.java
@@ -18,7 +18,7 @@ package org.pebble.core.decoding.iterators.ints;
 
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 

--- a/src/main/java/org/pebble/core/decoding/iterators/ints/StrictlyIncrementalListIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/ints/StrictlyIncrementalListIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,11 +14,14 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
-import org.pebble.core.encoding.DefaultParametersValues;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
+
+import static org.pebble.core.encoding.DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE;
 
 /**
  * Iterator over a compressed strictly incremental list of <code>int</code>s. See
@@ -52,8 +53,18 @@ public class StrictlyIncrementalListIterator extends BaseListIterator {
      * {@inheritDoc}
      */
     @Override
-    protected ReferenceIterator initializeReferenceIterator(final int listIndex, final InputBitStream inputBitStream) throws IOException {
-        return new StrictlyIncrementalReferenceIterator(listIndex, valueBitSize, minIntervalSize, inputBitStream, bytesStore);
+    protected ReferenceIterator initializeReferenceIterator(
+        final int listIndex,
+        final InputBitStream
+        inputBitStream
+    ) throws IOException {
+        return new StrictlyIncrementalReferenceIterator(
+            listIndex,
+            valueBitSize,
+            minIntervalSize,
+            inputBitStream,
+            bytesStore
+        );
     }
 
     /**
@@ -70,11 +81,31 @@ public class StrictlyIncrementalListIterator extends BaseListIterator {
         final int valueBitSize,
         final PebbleBytesStore bytesStore
     ) throws IOException {
+        return build(listIndex, valueBitSize, bytesStore, bytesStore.getInputBitStream(listIndex));
+    }
+
+    /**
+     * Instance builder.
+     * @param listIndex index of the current list.
+     * @param valueBitSize fixed number of bits used to represent value in list to be encoded. It can be any value
+     *                     between 1bit and 31 bits.
+     * @param bytesStore mapping between list offsets and data bytes arrays and bytes offsets.
+     * @param inputBitStream input bit stream used to read the compressed lists representations. The cursor must be
+     *                       positioned at the beginning of encoding.
+     * @return built instance.
+     * @throws IOException when there is an exception reading from <code>inputBitStream</code>.
+     */
+    public static StrictlyIncrementalListIterator build(
+        final int listIndex,
+        final int valueBitSize,
+        final PebbleBytesStore bytesStore,
+        final InputBitStream inputBitStream
+    ) throws IOException {
         return new StrictlyIncrementalListIterator(
             listIndex,
             valueBitSize,
-            DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE,
-            bytesStore.getInputBitStream(listIndex),
+            DEFAULT_MIN_INTERVAL_SIZE,
+            inputBitStream,
             bytesStore
         );
     }

--- a/src/main/java/org/pebble/core/decoding/iterators/ints/StrictlyIncrementalReferenceIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/ints/StrictlyIncrementalReferenceIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,9 +14,11 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 

--- a/src/main/java/org/pebble/core/decoding/iterators/longs/BaseListIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/longs/BaseListIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,9 +14,11 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 
@@ -128,7 +128,7 @@ abstract class BaseListIterator implements LongIterator {
      */
     @Override
     public Long next() {
-        long value = nextLong();
+        final long value = nextLong();
         return value == -1L ? null : value;
     }
 

--- a/src/main/java/org/pebble/core/decoding/iterators/longs/IncrementalListIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/longs/IncrementalListIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,8 +14,10 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 import org.pebble.core.encoding.DefaultParametersValues;
 
 import java.io.IOException;
@@ -85,7 +85,7 @@ public class IncrementalListIterator extends IncrementalListUniqueIterator {
         final PebbleBytesStore bytesStore
     ) throws IOException {
         final InputBitStream inputBitStream = bytesStore.getInputBitStream(listIndex);
-        RepeatsIterator repeatsIterator = new RepeatsIterator(inputBitStream);
+        final RepeatsIterator repeatsIterator = new RepeatsIterator(inputBitStream);
         inputBitStream.skipDeltas(repeatsIterator.getRemainingElements() * 2);
         return new IncrementalListIterator(
             listIndex,

--- a/src/main/java/org/pebble/core/decoding/iterators/longs/IncrementalListUniqueIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/longs/IncrementalListUniqueIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,8 +14,10 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 
@@ -73,7 +73,7 @@ class IncrementalListUniqueIterator extends BaseListIterator {
         final InputBitStream inputBitStream,
         final PebbleBytesStore bytesStore
     ) throws IOException {
-        RepeatsIterator repeatsIterator = new RepeatsIterator(inputBitStream);
+        final RepeatsIterator repeatsIterator = new RepeatsIterator(inputBitStream);
         inputBitStream.skipDeltas(repeatsIterator.getRemainingElements() * 2);
         return new IncrementalListUniqueIterator(listIndex, valueBitSize, minIntervalSize, inputBitStream, bytesStore);
     }

--- a/src/main/java/org/pebble/core/decoding/iterators/longs/IncrementalReferenceUniqueIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/longs/IncrementalReferenceUniqueIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,9 +14,11 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 

--- a/src/main/java/org/pebble/core/decoding/iterators/longs/ListIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/longs/ListIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,10 +14,12 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 import org.pebble.core.encoding.DefaultParametersValues;
 
 import java.io.IOException;
@@ -66,9 +66,9 @@ public class ListIterator extends StrictlyIncrementalListIterator {
                 index = inputBitStream.readDelta();
                 if ((index & 1) == 0) {
                     lastIndex = index / 2 + lastIndex;
-                    return valuesMap.get(lastIndex);
+                } else {
+                    lastIndex = lastIndex - (index + 1) / 2;
                 }
-                lastIndex = lastIndex - (index + 1) / 2;
                 return valuesMap.get(lastIndex);
             }
         } catch (IOException e) {

--- a/src/main/java/org/pebble/core/decoding/iterators/longs/ReferenceIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/longs/ReferenceIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,9 +14,11 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 

--- a/src/main/java/org/pebble/core/decoding/iterators/longs/StrictlyIncrementalListIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/longs/StrictlyIncrementalListIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,8 +14,10 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 import org.pebble.core.encoding.DefaultParametersValues;
 
 import java.io.IOException;

--- a/src/main/java/org/pebble/core/decoding/iterators/longs/StrictlyIncrementalReferenceIterator.java
+++ b/src/main/java/org/pebble/core/decoding/iterators/longs/StrictlyIncrementalReferenceIterator.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,9 +14,11 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.io.InputBitStream;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
 
 import java.io.IOException;
 

--- a/src/main/java/org/pebble/core/encoding/EncodingInfo.java
+++ b/src/main/java/org/pebble/core/encoding/EncodingInfo.java
@@ -1,0 +1,100 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.core.encoding;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+
+/**
+ * Class used to keep track of relevant encoding information.
+ */
+public class EncodingInfo {
+
+    private int currentIndex;
+    private long offset;
+
+    /**
+     * Sets encoding info with initial values.
+     */
+    public EncodingInfo() {
+        currentIndex = 0;
+        offset = 0L;
+    }
+
+    /**
+     * @return index for next encoded entry.
+     */
+    public int getCurrentIndex() {
+        return currentIndex;
+    }
+
+    /**
+     * @return current total numbers of bits used to encode past entries. Its value indicate the starting offset of the
+     * encoded representation of next entry.
+     */
+    public long getOffset() {
+        return offset;
+    }
+
+    /**
+     * Increments in one the current index.
+     * @return current index value before incrementation of its value.
+     */
+    public int incrementCurrentIndex() {
+        return currentIndex++;
+    }
+
+    /**
+     * Increments offset into <code>deltaOffset</code> and returns its new value.
+     * @param deltaOffset value into what will be incremented offset.
+     * @return value of offset after its incrementation.
+     */
+    public long incrementOffset(int deltaOffset) {
+        offset += deltaOffset;
+        return offset;
+    }
+
+    /**
+     * Stores current encoding info into <code>outputStream</code>.
+     * @param outputStream used to store the encoding info.
+     */
+    public void save(final OutputStream outputStream) {
+        PrintWriter printWriter = new PrintWriter(outputStream);
+        printWriter.printf("totalElements: %d\n", currentIndex);
+        printWriter.printf("totalSize: %d\n", offset);
+        printWriter.flush();
+    }
+
+    /**
+     * Loads encoding info from <code>inputStream</code>.
+     * @param inputStream from which encoding info is read.
+     * @return returns instance of encoding info with the values read from <code>inputStream</code>.
+     * @throws IOException in case there is an exception reading from <code>inputStream</code>.
+     */
+    public static EncodingInfo load(final InputStream inputStream) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        encodingInfo.currentIndex = Integer.parseInt(bufferedReader.readLine().split(": ")[1]);
+        encodingInfo.offset = Long.parseLong(bufferedReader.readLine().split(": ")[1]);
+        return encodingInfo;
+    }
+
+}

--- a/src/main/java/org/pebble/core/encoding/ints/IntOutputOffset.java
+++ b/src/main/java/org/pebble/core/encoding/ints/IntOutputOffset.java
@@ -1,5 +1,3 @@
-package org.pebble.core.encoding.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -15,6 +13,8 @@ package org.pebble.core.encoding.ints;
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+package org.pebble.core.encoding.ints;
 
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -237,15 +237,15 @@ public class IntOutputOffset extends OutputOffset {
         if (x < DELTA_OFFSET_X.length) {
             return DELTA_OFFSET_X[x];
         }
-        int log2x = lower_bound_log2(x + 1);
-        return log2x + 2 * lower_bound_log2(log2x + 1) + 1;
+        final int log2x = lowerBoundLog2(x + 1);
+        return log2x + 2 * lowerBoundLog2(log2x + 1) + 1;
     }
 
     private static int writeIntOffset(final int x, final int valueBitSize) {
         return valueBitSize;
     }
 
-    private static int lower_bound_log2(int x) {
+    private static int lowerBoundLog2(final int x) {
         return DefaultParametersValues.INT_BITS - Integer.numberOfLeadingZeros(x);
     }
 

--- a/src/main/java/org/pebble/core/encoding/ints/datastructures/IntReferenceListsStore.java
+++ b/src/main/java/org/pebble/core/encoding/ints/datastructures/IntReferenceListsStore.java
@@ -1,5 +1,3 @@
-package org.pebble.core.encoding.ints.datastructures;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -15,6 +13,8 @@ package org.pebble.core.encoding.ints.datastructures;
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+package org.pebble.core.encoding.ints.datastructures;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -37,7 +37,7 @@ public class IntReferenceListsStore {
      * Initializes a <code>IntReferenceListsStore</code> capable to store at most <code>size</code> lists with no more
      * than <code>maxRecursiveReferences</code> recursive references. If the number of lists exceeds <code>size</code>,
      * it will overwrite the oldest list on the store.
-     * @param size maximum numbers of lists to be stored.
+     * @param size maximum number of lists to be stored.
      * @param maxRecursiveReferences maximum number of allowed recursive references.
      * @param minListSize Minimum size of list required to be added to the store.
      * @param referenceListIndex index used to find the best reference list candidate.
@@ -46,7 +46,7 @@ public class IntReferenceListsStore {
         final int size,
         final int maxRecursiveReferences,
         final int minListSize,
-        IntReferenceListsIndex referenceListIndex
+        final IntReferenceListsIndex referenceListIndex
     ) {
         index = 0;
         this.maxRecursiveReferences = maxRecursiveReferences;
@@ -63,7 +63,7 @@ public class IntReferenceListsStore {
      *
      * @param offset position of the <code>list</code> respect to the list of lists, starting from zero.
      * @param recursiveReferences number of recursive reference of the <code>list</code>.
-     * @param list to add to the store.
+     * @param list to append to the store.
      * @return true when the <code>list</code> is added to the store and false when is not.
      */
     public boolean add(final int offset, final int recursiveReferences, final IntList list) {
@@ -85,7 +85,7 @@ public class IntReferenceListsStore {
      * Removes from the store the given <code>list</code>.
      * @param list List to be removed from the store.
      */
-    public void remove(ReferenceList list) {
+    public void remove(final ReferenceList list) {
         referenceListIndex.removeListFromListsInvertedIndex(list.index, list.list);
         lists[list.index] = null;
     }
@@ -123,7 +123,7 @@ public class IntReferenceListsStore {
         private final int recursiveReferences;
         private final int index;
 
-        private ReferenceList(IntList list, int offset, int recursiveReferences, int index) {
+        private ReferenceList(final IntList list, final int offset, final int recursiveReferences, final int index) {
             this.index = index;
             this.list = list;
             this.offset = offset;

--- a/src/main/java/org/pebble/core/encoding/longs/LongOutputOffset.java
+++ b/src/main/java/org/pebble/core/encoding/longs/LongOutputOffset.java
@@ -1,5 +1,3 @@
-package org.pebble.core.encoding.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -15,6 +13,8 @@ package org.pebble.core.encoding.longs;
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+package org.pebble.core.encoding.longs;
 
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.longs.LongIterator;
@@ -238,15 +238,15 @@ public class LongOutputOffset extends OutputOffset {
         if (x < DELTA_OFFSET_X.length) {
             return DELTA_OFFSET_X[(int) x];
         }
-        long log2x = lower_bound_log2(x + 1);
-        return (int) (log2x + 2 * lower_bound_log2(log2x + 1) + 1);
+        final long log2x = lowerBoundLog2(x + 1);
+        return (int) (log2x + 2 * lowerBoundLog2(log2x + 1) + 1);
     }
 
     private static int writeLongOffset(final long x, final int valueBitSize) {
         return valueBitSize;
     }
 
-    private static long lower_bound_log2(long x) {
+    private static long lowerBoundLog2(final long x) {
         return DefaultParametersValues.LONG_BITS - Long.numberOfLeadingZeros(x);
     }
 

--- a/src/main/java/org/pebble/core/encoding/longs/datastructures/LongReferenceListsStore.java
+++ b/src/main/java/org/pebble/core/encoding/longs/datastructures/LongReferenceListsStore.java
@@ -1,5 +1,3 @@
-package org.pebble.core.encoding.longs.datastructures;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -15,6 +13,8 @@ package org.pebble.core.encoding.longs.datastructures;
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+package org.pebble.core.encoding.longs.datastructures;
 
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongList;
@@ -37,7 +37,7 @@ public class LongReferenceListsStore {
      * Initializes a <code>LongReferenceListsStore</code> capable to store at most <code>size</code> lists with no more
      * than <code>maxRecursiveReferences</code> recursive references. If the number of lists exceeds <code>size</code>,
      * it will overwrite the oldest list on the store.
-     * @param size maximum numbers of lists to be stored.
+     * @param size maximum number of lists to be stored.
      * @param maxRecursiveReferences maximum number of allowed recursive references.
      * @param minListSize Minimum size of list required to be added to the store.
      * @param referenceListIndex index used to find the best reference list candidate.
@@ -46,7 +46,7 @@ public class LongReferenceListsStore {
         final int size,
         final int maxRecursiveReferences,
         final int minListSize,
-        LongReferenceListsIndex referenceListIndex
+        final LongReferenceListsIndex referenceListIndex
     ) {
         index = 0;
         this.maxRecursiveReferences = maxRecursiveReferences;
@@ -63,7 +63,7 @@ public class LongReferenceListsStore {
      *
      * @param offset position of the <code>list</code> respect to the list of lists, starting from zero.
      * @param recursiveReferences number of recursive reference of the <code>list</code>.
-     * @param list to add to the store.
+     * @param list to append to the store.
      * @return true when the <code>list</code> is added to the store and false when is not.
      */
     public boolean add(final int offset, final int recursiveReferences, final LongList list) {
@@ -85,7 +85,7 @@ public class LongReferenceListsStore {
      * Removes from the store the given <code>list</code>.
      * @param list List to be removed from the store.
      */
-    public void remove(ReferenceList list) {
+    public void remove(final ReferenceList list) {
         referenceListIndex.removeListFromListsInvertedIndex(list.index, list.list);
         lists[list.index] = null;
     }
@@ -123,7 +123,7 @@ public class LongReferenceListsStore {
         private final int recursiveReferences;
         private final int index;
 
-        private ReferenceList(LongList list, int offset, int recursiveReferences, int index) {
+        private ReferenceList(final LongList list, final int offset, final int recursiveReferences, final int index) {
             this.index = index;
             this.list = list;
             this.offset = offset;

--- a/src/main/java/org/pebble/core/package-info.java
+++ b/src/main/java/org/pebble/core/package-info.java
@@ -1,9 +1,4 @@
 /**
- * Provides Pebble's core algorithm implementation.
- */
-package org.pebble.core;
-
-/**
  *  Copyright 2015 Groupon
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,3 +13,8 @@ package org.pebble.core;
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+/**
+ * Provides Pebble's core algorithm implementation.
+ */
+package org.pebble.core;

--- a/src/main/java/org/pebble/types/TypeIntDecoder.java
+++ b/src/main/java/org/pebble/types/TypeIntDecoder.java
@@ -1,0 +1,92 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types;
+
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import org.pebble.core.PebbleBytesStore;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Abstract class used to decode a list of complex types from an encoded list of integers obtained using an
+ * extending instance of {@link org.pebble.types.TypeIntEncoder}. This class defines the base for such kind of decoders,
+ * expanding pebble capabilities to decompress complex data types.
+ * @param <T> type supported by the decoder.
+ */
+public abstract class TypeIntDecoder<T> {
+
+    /**
+     * Mapping between list offsets and data bytes arrays and bytes offsets.
+     */
+    protected final PebbleBytesStore bytesStore;
+
+    /**
+     *
+     * @param bytesStore mapping between list offsets and data bytes arrays and bytes offsets.
+     */
+    public TypeIntDecoder(final PebbleBytesStore bytesStore) {
+        this.bytesStore = bytesStore;
+    }
+
+    /**
+     * Builds iterator over a list of complex types <code>T</code>.
+     * @param listIndex index of the current list.
+     * @param valueBitSize fixed number of bits used to represent the values in the encoded list. It can be any value
+     *                     between 1bit and 31 bits.
+     * @return iterator of decoded list.
+     * @throws IOException in case there is an exception reading the information required to build iterator.
+     */
+    public abstract Iterator<T> read(final int listIndex, final int valueBitSize) throws IOException;
+
+    /**
+     * Base class used to define complex types <code>T</code> iterator.
+     */
+    protected abstract class TypeIterator implements Iterator<T> {
+
+        /**
+         * Iterator over the list containing the integers resulting from the encoding of complex types.
+         */
+        protected final IntIterator iterator;
+
+        /**
+         *
+         * @param iterator over the list containing the integers resulting from the encoding of complex types.
+         */
+        public TypeIterator(final IntIterator iterator) {
+            this.iterator = iterator;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        /**
+         * Unsupported method. The list cannot be modified.
+         */
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("List is immutable");
+        }
+
+    }
+
+}

--- a/src/main/java/org/pebble/types/TypeIntEncoder.java
+++ b/src/main/java/org/pebble/types/TypeIntEncoder.java
@@ -1,0 +1,54 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types;
+
+import it.unimi.dsi.fastutil.ints.IntList;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Abstract class used to encode a list of a complex types into a list of integers that can be compressed by the core
+ * pebble functionality. This class defines the base for such kind of encoders, expanding pebble capabilities to
+ * compress complex data types.
+ * @param <T> type supported by the encoder.
+ */
+public abstract class TypeIntEncoder<T> {
+
+    /**
+     * Encodes a list of complex data types <code>T</code> into a list of integers applying
+     * {@link org.pebble.types.TypeIntEncoder#encode(Object)} function.
+     * @param list containing complex elements types.
+     * @param listBuffer where the encoding will be stored.
+     * @throws IOException in case there is an exception storing the encoded elements.
+     */
+    public void setIntList(final List<T> list, final IntList listBuffer) throws IOException {
+        listBuffer.clear();
+        for (T element : list) {
+            listBuffer.add(encode(element));
+        }
+    }
+
+    /**
+     * Encodes an <code>element</code> into an integer.
+     * @param element to be encoded to an integer.
+     * @return <code>int</code> value of encoded <code>element</code>.
+     * @throws IOException in case there is an exception storing the encoded element.
+     */
+    protected abstract int encode(final T element)  throws IOException;
+
+}

--- a/src/main/java/org/pebble/types/TypeMapDecoder.java
+++ b/src/main/java/org/pebble/types/TypeMapDecoder.java
@@ -1,0 +1,89 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types;
+
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.io.InputBitStream;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.decoding.iterators.ints.ListIterator;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Abstract class used to recover list of original complex types from an encoded list of integers obtained using an
+ * extending instance of {@link org.pebble.types.TypeMapEncoder}. This class takes the list index stored
+ * on the integer list to lookup the offset of the encoded original complex type and decodes the stored value.
+ * @param <T> type supported by the encoder.
+ */
+public abstract class TypeMapDecoder<T> extends TypeIntDecoder<T> {
+
+    /**
+     *
+     * @param bytesStore mapping between list offsets and data bytes arrays and bytes offsets.
+     */
+    public TypeMapDecoder(final PebbleBytesStore bytesStore) {
+        super(bytesStore);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Iterator<T> read(final int listIndex, final int valueBitSize) throws IOException {
+        return new MappedTypeIterator(ListIterator.build(listIndex, valueBitSize, bytesStore));
+    }
+
+    /**
+     * Reads encoded element.
+     * @param inputBitStream input bit stream used to read the encoded value from.
+     * @return value of decoded element.
+     * @throws IOException in case there is an exception reading the encoded element from <code>inputBitStream</code>.
+     */
+    protected abstract T read(final InputBitStream inputBitStream) throws IOException;
+
+    /**
+     * Iterator over decoded complex types <code>T</code>.
+     */
+    protected class MappedTypeIterator extends TypeIterator {
+
+        /**
+         *
+         * @param iterator over the list contained the integers resulting from the encoding of complex types.
+         */
+        public MappedTypeIterator(IntIterator iterator) {
+            super(iterator);
+        }
+
+        /**
+         * Decodes current element by using the index list stored in current element value, positions the cursor
+         * where the encoding starts for the encoded element and decode its value by calling
+         * {@link org.pebble.types.TypeMapDecoder#read(it.unimi.dsi.io.InputBitStream)}.
+         * @return current decoded element.
+         * @throws java.lang.IllegalStateException in case there is an exception reading encoded element.
+         */
+        @Override
+        public T next() {
+            try {
+                return read(bytesStore.getInputBitStream(iterator.nextInt()));
+            } catch (IOException e) {
+                throw new IllegalStateException(e.getMessage());
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/pebble/types/TypeMapEncoder.java
+++ b/src/main/java/org/pebble/types/TypeMapEncoder.java
@@ -1,0 +1,123 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.io.OutputBitStream;
+import org.pebble.core.PebbleOffsetsStoreWriter;
+import org.pebble.core.encoding.EncodingInfo;
+
+import java.io.IOException;
+
+/**
+ * Abstract class used to encode a list of a complex types into a list of integers that can be compressed by the core
+ * pebble functionality. This encoder writes into the output stream a generic encoding of the values that needs to be
+ * implemented on subclasses and then replaces its value by the list index of the encoding. This enable the compression
+ * of data types that cannot be transformed into integers and recovered back from its value or in cases where its
+ * transformation do not have good compression properties. This class defines the base for such kind of encoders,
+ * expanding the capabilities of pebble to compress complex data types.
+ * @param <T> type supported by the encoder.
+ */
+public abstract class TypeMapEncoder<T> extends TypeIntEncoder<T> {
+
+    /**
+     * Output stream where a new encoded element will be written.
+     */
+    protected final OutputBitStream outputBitStream;
+
+    /**
+     * Stores the current offset after each encoded element is stored.
+     */
+    protected final PebbleOffsetsStoreWriter offsetsStore;
+
+    /**
+     * Used to keep track of relevant encoding information.
+     */
+    protected final EncodingInfo encodingInfo;
+
+    private static final int MISSING_MAP_VALUE = -1;
+
+    private final int referenceWindowSize;
+    private final T[] buffer;
+    private final Object2IntOpenHashMap<T> map;
+
+    private int bufferIndex;
+
+    /**
+     *
+     * @param referenceWindowSize size of the maximum size of the list index between current list and its encoded value
+     *                            list index.
+     * @param outputBitStream output stream where a new encoded element will be written.
+     * @param offsetsStore stores the current offset after each element is written.
+     * @param encodingInfo encodingInfo used to keep track of relevant encoding information.
+     */
+    public TypeMapEncoder(
+        final int referenceWindowSize,
+        final OutputBitStream outputBitStream,
+        final PebbleOffsetsStoreWriter offsetsStore,
+        final EncodingInfo encodingInfo
+    ) {
+        this.referenceWindowSize = referenceWindowSize;
+        this.outputBitStream = outputBitStream;
+        this.offsetsStore = offsetsStore;
+        this.encodingInfo = encodingInfo;
+        this.buffer = (T[]) new Object[referenceWindowSize];
+        this.bufferIndex = 0;
+        this.map = new Object2IntOpenHashMap<T>();
+        this.map.defaultReturnValue(MISSING_MAP_VALUE);
+    }
+
+    /**
+     * This methods keeps a map in memory of all elements that has been already encoded. The maximum number of elements
+     * the map can hold is <code>referenceWindowSize</code>. This allows the control of the memory used by the encoder
+     * and also limits the length of the references used in the mapping. When the number of encoded elements is bigger
+     * than <code>referenceWindowSize</code>, elements with longest references in the map will by elements with shorter
+     * references.
+     * @param element to be encoded to an integer.
+     * @return <code>int</code> value of encoded <code>element</code>.
+     * @throws IOException in case there is an exception storing the encoded element.
+     */
+    @Override
+    protected int encode(T element) throws IOException {
+        int index = map.getInt(element);
+        if (index == MISSING_MAP_VALUE || (encodingInfo.getCurrentIndex() - index) > referenceWindowSize) {
+            offsetsStore.append(encodingInfo.incrementOffset(write(element)));
+            int deleteObjectIndex;
+            if (
+                buffer[bufferIndex] != null &&
+                (deleteObjectIndex = map.getInt(buffer[bufferIndex])) != MISSING_MAP_VALUE &&
+                (encodingInfo.getCurrentIndex() - deleteObjectIndex) >= referenceWindowSize
+            ) {
+                map.remove(buffer[bufferIndex]);
+            }
+            buffer[bufferIndex] = element;
+            bufferIndex = (bufferIndex + 1) % referenceWindowSize;
+            index = encodingInfo.incrementCurrentIndex();
+            map.put(element, index);
+        }
+        return index;
+    }
+
+    /**
+     * Writes encoded value of <code>element</code>.
+     * @param element to be written.
+     * @return numbers of bits used to write the encoded <code>element</code>.
+     * @throws IOException when there is an exception writing <code>element</code>.
+     */
+    protected abstract int write(final T element) throws IOException;
+
+}

--- a/src/main/java/org/pebble/types/package-info.java
+++ b/src/main/java/org/pebble/types/package-info.java
@@ -1,0 +1,20 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Provides Pebble's encoding and decoding generics types functionality.
+ */
+package org.pebble.types;

--- a/src/main/java/org/pebble/types/text/TextIntDecoder.java
+++ b/src/main/java/org/pebble/types/text/TextIntDecoder.java
@@ -1,0 +1,55 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.text;
+
+import it.unimi.dsi.io.InputBitStream;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.types.TypeMapDecoder;
+
+import java.io.IOException;
+
+/**
+ * Class used to decode a list of {@link java.lang.String} from an encoded list of integers obtained using an
+ * instance of {@link org.pebble.types.text.TextIntEncoder}.
+ */
+public class TextIntDecoder extends TypeMapDecoder<String> {
+
+    private final byte[] buffer;
+
+    /**
+     *
+     * @param bytesStore mapping between list offsets and data bytes arrays and bytes offsets.
+     */
+    public TextIntDecoder(final PebbleBytesStore bytesStore) {
+        super(bytesStore);
+        this.buffer = new byte[TextIntEncoder.MAX_TEXT_LENGTH];
+    }
+
+    /**
+     * Reads encoded string by reading its size delta encoded and then reading its bytes representation.
+     * @param inputBitStream input bit stream used to read the encoded value from.
+     * @return value of decoded element.
+     * @throws IOException in case there is an exception reading the encoded element from <code>inputBitStream</code>.
+     */
+    @Override
+    protected String read(final InputBitStream inputBitStream) throws IOException {
+        final int size = inputBitStream.readDelta();
+        inputBitStream.read(buffer, size * 8);
+        return new String(buffer, 0, size);
+    }
+
+}

--- a/src/main/java/org/pebble/types/text/TextIntEncoder.java
+++ b/src/main/java/org/pebble/types/text/TextIntEncoder.java
@@ -1,0 +1,78 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.text;
+
+import it.unimi.dsi.io.OutputBitStream;
+import org.pebble.core.PebbleOffsetsStoreWriter;
+import org.pebble.core.encoding.EncodingInfo;
+import org.pebble.types.TypeMapEncoder;
+
+import java.io.IOException;
+
+/**
+ * Class used to encode a list of {@link java.lang.String} types into a list of integers that can be compressed by
+ * the core pebble functionality.
+ */
+public class TextIntEncoder extends TypeMapEncoder<String> {
+
+    /**
+     * Maximum supported length of text to be decoded.
+     */
+    public static final int MAX_TEXT_LENGTH = 1024;
+
+    /**
+     *
+     * @param referenceWindowSize size of the maximum size of the list index between current list and its encoded value
+     *                            list index.
+     * @param outputBitStream output stream where a new encoded element will be written.
+     * @param offsetsStore stores the current offset after each element is written.
+     * @param encodingInfo encodingInfo used to keep track of relevant encoding information.
+     */
+    public TextIntEncoder(
+        final int referenceWindowSize,
+        final OutputBitStream outputBitStream,
+        final PebbleOffsetsStoreWriter offsetsStore,
+        final EncodingInfo encodingInfo
+    ) {
+        super(referenceWindowSize, outputBitStream, offsetsStore, encodingInfo);
+    }
+
+    /**
+     * Store the length of the text stored in <code>element</code> using delta encoding and then stores
+     * the bytes of the string characters.
+     * @param element to be written.
+     * @return numbers of bits used to write the encoded <code>element</code>.
+     * @throws IOException when there is an exception writing <code>element</code>.
+     * @throws IllegalArgumentException when the length of <code>element</code> is bigger than
+     * {@link TextIntEncoder#MAX_TEXT_LENGTH}.
+     */
+    @Override
+    protected int write(final String element) throws IOException {
+        final int size = element.length();
+        if (size > TextIntEncoder.MAX_TEXT_LENGTH) {
+            throw new IllegalArgumentException(String.format(
+                "element \"%s\" of length: %d, cannot be bigger than %d",
+                element,
+                element.length(),
+                MAX_TEXT_LENGTH
+            ));
+        }
+        final int offset = outputBitStream.writeDelta(size);
+        return offset + (int) outputBitStream.write(element.getBytes(), size * 8);
+    }
+
+}

--- a/src/main/java/org/pebble/types/text/package-info.java
+++ b/src/main/java/org/pebble/types/text/package-info.java
@@ -1,9 +1,4 @@
 /**
- * Contains utility classes which extends Pebble's core compression functionality.
- */
-package org.pebble.utils.decoding;
-
-/**
  *  Copyright 2015 Groupon
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,3 +13,8 @@ package org.pebble.utils.decoding;
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+/**
+ * Provides Pebble's encoding and decoding Texts functionality.
+ */
+package org.pebble.types.text;

--- a/src/main/java/org/pebble/types/timestamp/TimestampIntDecoder.java
+++ b/src/main/java/org/pebble/types/timestamp/TimestampIntDecoder.java
@@ -1,0 +1,67 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.timestamp;
+
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.decoding.iterators.ints.ListIterator;
+import org.pebble.types.TypeIntDecoder;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.Iterator;
+
+/**
+ * Class used to decode a list of {@link java.sql.Timestamp} from an encoded list of integers obtained using an
+ * instance of {@link org.pebble.types.timestamp.TimestampIntEncoder}.
+ */
+public class TimestampIntDecoder extends TypeIntDecoder<Timestamp> {
+
+    /**
+     *
+     * @param bytesStore mapping between list offsets and data bytes arrays and bytes offsets.
+     */
+    public TimestampIntDecoder(final PebbleBytesStore bytesStore) {
+        super(bytesStore);
+    }
+
+    /**
+     * Builds iterator over a list of {@link java.sql.Timestamp} list.
+     * @param listIndex index of the current list.
+     * @param valueBitSize fixed number of bits used to represent the values in the mapping list. It can be any value
+     *                     between 1bit and 31 bits.
+     * @return iterator of decoded list.
+     * @throws IOException in case there is an exception reading the information required to build iterator.
+     */
+    public Iterator<Timestamp> read(final int listIndex, final int valueBitSize) throws IOException {
+        return new TimestampIterator(ListIterator.build(listIndex, valueBitSize, bytesStore));
+    }
+
+    private class TimestampIterator extends TypeIterator {
+
+        public TimestampIterator(final IntIterator iterator) {
+            super(iterator);
+        }
+
+        @Override
+        public Timestamp next() {
+            return new Timestamp(iterator.nextInt() * 1000L);
+        }
+
+    }
+
+}

--- a/src/main/java/org/pebble/types/timestamp/TimestampIntEncoder.java
+++ b/src/main/java/org/pebble/types/timestamp/TimestampIntEncoder.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.timestamp;
+
+import org.pebble.types.TypeIntEncoder;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+
+/**
+ * Class used to encode a list of {@link java.sql.Timestamp} types into a list of integers that can be compressed by
+ * the core pebble functionality.
+ */
+public class TimestampIntEncoder extends TypeIntEncoder<Timestamp> {
+
+    /**
+     * Gets the unix timestamp of <code>element</code> in seconds and store it as integer.
+     * @param element to be encoded.
+     * @return <code>int</code> value of encoded <code>element</code>.
+     * @throws IOException is never raised. Current encoding implementation cannot raise this exception.
+     */
+    @Override
+    protected int encode(final Timestamp element) throws IOException {
+        return (int) (element.getTime() / 1000);
+    }
+
+}

--- a/src/main/java/org/pebble/types/timestamp/package-info.java
+++ b/src/main/java/org/pebble/types/timestamp/package-info.java
@@ -1,0 +1,20 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Provides Pebble's encoding and decoding Timestamps functionality.
+ */
+package org.pebble.types.timestamp;

--- a/src/main/java/org/pebble/types/uuid/UUIDIntDecoder.java
+++ b/src/main/java/org/pebble/types/uuid/UUIDIntDecoder.java
@@ -1,0 +1,52 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.uuid;
+
+import it.unimi.dsi.io.InputBitStream;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.types.TypeMapDecoder;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Class used to decode a list of {@link java.util.UUID} from an encoded list of integers obtained using an
+ * instance of {@link org.pebble.types.uuid.UUIDIntEncoder}.
+ */
+public class UUIDIntDecoder extends TypeMapDecoder<UUID> {
+
+    /**
+     *
+     * @param bytesStore mapping between list offsets and data bytes arrays and bytes offsets.
+     */
+    public UUIDIntDecoder(final PebbleBytesStore bytesStore) {
+        super(bytesStore);
+    }
+
+    /**
+     * Decodes uuid by reading the 64 most significant bits and least 64 significant bits stored as longs binary
+     * representation.
+     * @param inputBitStream input bit stream used to read the encoded value from.
+     * @return value of decoded element.
+     * @throws IOException in case there is an exception reading the encoded element from <code>inputBitStream</code>.
+     */
+    @Override
+    protected UUID read(final InputBitStream inputBitStream) throws IOException {
+        return new UUID(inputBitStream.readLong(64), inputBitStream.readLong(64));
+    }
+
+}

--- a/src/main/java/org/pebble/types/uuid/UUIDIntEncoder.java
+++ b/src/main/java/org/pebble/types/uuid/UUIDIntEncoder.java
@@ -1,0 +1,63 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.uuid;
+
+import it.unimi.dsi.io.OutputBitStream;
+import org.pebble.core.PebbleOffsetsStoreWriter;
+import org.pebble.core.encoding.EncodingInfo;
+import org.pebble.types.TypeMapEncoder;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Class used to encode a list of {@link java.util.UUID} types into a list of integers that can be compressed by
+ * the core pebble functionality.
+ */
+public class UUIDIntEncoder extends TypeMapEncoder<UUID> {
+
+    /**
+     *
+     * @param referenceWindowSize size of the maximum size of the list index between current list and its encoded value
+     *                            list index.
+     * @param outputBitStream output stream where a new encoded element will be written.
+     * @param offsetsStore stores the current offset after each element is written.
+     * @param encodingInfo encodingInfo used to keep track of relevant encoding information.
+     */
+    public UUIDIntEncoder(
+        final int referenceWindowSize,
+        final OutputBitStream outputBitStream,
+        final PebbleOffsetsStoreWriter offsetsStore,
+        final EncodingInfo encodingInfo
+    ) {
+        super(referenceWindowSize, outputBitStream, offsetsStore, encodingInfo);
+    }
+
+    /**
+     * Store the 64 most significant bits and the 64 least significant bits as longs binary representation.
+     * @param element to be written.
+     * @return numbers of bits used to write the encoded <code>element</code>.
+     * @throws IOException when there is an exception writing <code>element</code>.
+     */
+    @Override
+    protected int write(final UUID element) throws IOException {
+        outputBitStream.writeLong(element.getMostSignificantBits(), 64);
+        outputBitStream.writeLong(element.getLeastSignificantBits(), 64);
+        return 128;
+    }
+
+}

--- a/src/main/java/org/pebble/types/uuid/package-info.java
+++ b/src/main/java/org/pebble/types/uuid/package-info.java
@@ -1,0 +1,20 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * Provides Pebble's encoding and decoding UUIDs functionality.
+ */
+package org.pebble.types.uuid;

--- a/src/main/java/org/pebble/utils/BytesArrayPebbleBytesStore.java
+++ b/src/main/java/org/pebble/utils/BytesArrayPebbleBytesStore.java
@@ -1,5 +1,3 @@
-package org.pebble.utils.decoding;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,10 +14,13 @@ package org.pebble.utils.decoding;
  *  limitations under the License.
  */
 
-import org.pebble.core.decoding.PebbleBytesStore;
+package org.pebble.utils;
+
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
 
 /**
- * Wrapper of a single byte array which implements the {@link org.pebble.core.decoding.PebbleBytesStore}
+ * Wrapper of a single byte array which implements the {@link org.pebble.core.PebbleBytesStore}
  * interface. This implementation loads into main memory the full compressed data stored at <code>store</code> byte
  * array. Given the maximum number of an array 2^31-1 in java, this implementation is limited to compressed data sets
  * that fit in a single array. Approximately not bigger than 1.9[Gb].
@@ -27,25 +28,25 @@ import org.pebble.core.decoding.PebbleBytesStore;
 public class BytesArrayPebbleBytesStore extends PebbleBytesStore {
 
     private final byte[] store;
-    private final long[] offsets;
+    private final PebbleOffsetsStore offsetsStore;
 
     /**
      * Initialize a pebble byte store containing the compressed lists stored on <code>store</code> and its respective
      * offsets contained at <code>offsets</code>.
      * @param store byte array containing the bits of the compressed lists.
-     * @param offsets offsets indicating the start in bits of each compressed list representation stored in
-     *                <code>store</code>.
+     * @param offsetsStore store containing the offsets indicating the start in bits of each compressed list
+     *                     representation stored in <code>store</code>.
      */
-    public BytesArrayPebbleBytesStore(byte[] store, long[] offsets) {
-       this.store = store;
-        this.offsets = offsets;
+    public BytesArrayPebbleBytesStore(final byte[] store, PebbleOffsetsStore offsetsStore) {
+        this.store = store;
+        this.offsetsStore = offsetsStore;
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public byte[] get(int listIndex) {
+    public byte[] get(final int listIndex) {
         return store;
     }
 
@@ -53,7 +54,7 @@ public class BytesArrayPebbleBytesStore extends PebbleBytesStore {
      * {@inheritDoc}
      */
     @Override
-    public long offset(int listIndex) {
-        return this.offsets[listIndex];
+    public long offset(final int listIndex) {
+        return offsetsStore.get(listIndex);
     }
 }

--- a/src/main/java/org/pebble/utils/LongListPebbleOffsetsStore.java
+++ b/src/main/java/org/pebble/utils/LongListPebbleOffsetsStore.java
@@ -1,0 +1,68 @@
+package org.pebble.utils;
+
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import org.pebble.core.PebbleOffsetsStore;
+import org.pebble.core.PebbleOffsetsStoreWriter;
+
+import java.io.IOException;
+
+/**
+ * Class that implements offsets store for reading and writing offsets interfaces. This implementation
+ * stores the offsets in a {@link it.unimi.dsi.fastutil.longs.LongList} and therefore any compression is performed
+ * on the data. This is just a simple implementation that works as an example on how the
+ * {@link org.pebble.core.PebbleOffsetsStore} and {@link org.pebble.core.PebbleOffsetsStoreWriter} can be implemented.
+ * Though it should not be used on big data sets.
+ */
+public class LongListPebbleOffsetsStore implements PebbleOffsetsStore, PebbleOffsetsStoreWriter {
+
+    protected final LongList offsets;
+
+    /**
+     * Initializes and empty offsets store
+     */
+    public LongListPebbleOffsetsStore() {
+        offsets = new LongArrayList();
+    }
+
+    /**
+     * Initializes an store containing the offsets provided in <code>offsets</code>.
+     * @param offsets array containing offsets.
+     */
+    public LongListPebbleOffsetsStore(long[] offsets) {
+        this.offsets = new LongArrayList(offsets);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void append(long offset) throws IOException {
+        offsets.add(offset);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long get(int index) {
+        return offsets.get(index);
+    }
+
+}

--- a/src/test/java/org/pebble/core/IncrementalIntListsTest.java
+++ b/src/test/java/org/pebble/core/IncrementalIntListsTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,13 +14,14 @@ package org.pebble.core;
  *  limitations under the License.
  */
 
+package org.pebble.core;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.FastIntegrationTest;
-import org.pebble.core.decoding.PebbleBytesStore;
 import org.pebble.core.decoding.iterators.Helper.Input;
 import org.pebble.core.decoding.iterators.ints.IncrementalListIterator;
 import org.pebble.core.encoding.Helper;
@@ -30,7 +29,8 @@ import org.pebble.core.encoding.OutputSuccinctStream;
 import org.pebble.core.encoding.ints.datastructures.IntReferenceListsIndex;
 import org.pebble.core.encoding.ints.datastructures.IntReferenceListsStore;
 import org.pebble.core.encoding.ints.datastructures.InvertedListIntReferenceListsIndex;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -98,8 +98,8 @@ public class IncrementalIntListsTest {
             "1 1 1 01101 00101 0101 01100 1" +
             "0101 1 0100 0100 01100 0100 1 1 1 1"
         );
-        final long[] offsets = new long[] {0L, 23L};
-        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 23L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         final int valueBitSize = 5;
         final IntList[] expectedLists = new IntList[] {
             new IntArrayList(new int[] {5, 8, 12, 13}),

--- a/src/test/java/org/pebble/core/IncrementalLongListsTest.java
+++ b/src/test/java/org/pebble/core/IncrementalLongListsTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,13 +14,14 @@ package org.pebble.core;
  *  limitations under the License.
  */
 
+package org.pebble.core;
+
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongList;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.FastIntegrationTest;
-import org.pebble.core.decoding.PebbleBytesStore;
 import org.pebble.core.decoding.iterators.Helper.Input;
 import org.pebble.core.decoding.iterators.longs.IncrementalListIterator;
 import org.pebble.core.encoding.Helper;
@@ -30,7 +29,8 @@ import org.pebble.core.encoding.OutputSuccinctStream;
 import org.pebble.core.encoding.longs.datastructures.InvertedListLongReferenceListsIndex;
 import org.pebble.core.encoding.longs.datastructures.LongReferenceListsIndex;
 import org.pebble.core.encoding.longs.datastructures.LongReferenceListsStore;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -98,8 +98,8 @@ public class IncrementalLongListsTest {
             "1 1 1 01101 00101 0101 01100 1" +
             "0101 1 0100 0100 01100 0100 1 1 1 1"
         );
-        final long[] offsets = new long[] {0L, 23L};
-        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 23L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         final int valueBitSize = 5;
         final LongList[] expectedLists = new LongList[] {
             new LongArrayList(new long[] {5L, 8L, 12L, 13L}),

--- a/src/test/java/org/pebble/core/IntListsTest.java
+++ b/src/test/java/org/pebble/core/IntListsTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,13 +14,14 @@ package org.pebble.core;
  *  limitations under the License.
  */
 
+package org.pebble.core;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.FastIntegrationTest;
-import org.pebble.core.decoding.PebbleBytesStore;
 import org.pebble.core.decoding.iterators.Helper.Input;
 import org.pebble.core.decoding.iterators.ints.ListIterator;
 import org.pebble.core.encoding.Helper;
@@ -30,7 +29,8 @@ import org.pebble.core.encoding.OutputSuccinctStream;
 import org.pebble.core.encoding.ints.datastructures.IntReferenceListsIndex;
 import org.pebble.core.encoding.ints.datastructures.IntReferenceListsStore;
 import org.pebble.core.encoding.ints.datastructures.InvertedListIntReferenceListsIndex;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -62,12 +62,12 @@ public class IntListsTest {
             new IntArrayList(new int[] {13, 13, 5, 8, 5, 8, 12, 13, 12, 12})
         };
         /**
-         * list=[12, 8, 5, 12, 13, 5, 13, 8, 5, 12, 8]
-         * values=[5, 8, 12, 13] indexes=[2, 1, 0, 2, 3, 0, 3, 1, 0, 2, 1]
+         * list=[12, 8, 5, 12, 13, 5, 13, 8]
+         * values=[5, 8, 12, 13] indexes=[2, 1, 0, 2, 3, 0, 3, 1]
          * reference=[0], intervals=[0], delta=[4, 5, 2, 3, 0],   indexes=[4, 4, 1, 1, 4, 2, 5, 6, 3]
          * 1              1              101   00101 11   100   1 101   101   10   10   101   11   110   111   100
          * 1              1              3-01  00101 2-1  3-00  1 3-01  3-01  2-0  2-0  3-01  2-1  3-10  3-11  3-00
-         * 1              1              11-01 00101 01-1 11-00 1 11-01 11-01 10-0 10-0 11-01 10-1 11-10 11-11 11-00
+         * 1              1              11-01 00101 10-1 11-00 1 11-01 11-01 10-0 10-0 11-01 10-1 11-10 11-11 11-00
          * 1              1              01101 00101 0101 01100 1 01101 01101 0100 0100 01101 0101 01110 01111 01100
          * list=[13, 13, 5, 8, 5, 8, 12, 13, 12, 12]
          * values=[5, 8, 12, 13] indexes=[3, 3, 0, 1, 0, 1, 2, 3, 2, 2]
@@ -100,8 +100,8 @@ public class IntListsTest {
             "1 1 01101 00101 0101 01100 1 01101 01101 0100 0100 01101 0101 01110 01111 01100" +
             "0100 1 1 1 1 01111 01111 1 01110 0101 0100 0101 0101 0101 0100 1"
         );
-        final long[] offsets = new long[] {0L, 64L};
-        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 64L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         final int valueBitSize = 5;
         final IntList[] expectedLists = new IntList[] {
             new IntArrayList(new int[] {12, 8, 5, 12, 13, 5, 13, 8}),

--- a/src/test/java/org/pebble/core/LongListsTest.java
+++ b/src/test/java/org/pebble/core/LongListsTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,13 +14,14 @@ package org.pebble.core;
  *  limitations under the License.
  */
 
+package org.pebble.core;
+
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongList;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.FastIntegrationTest;
-import org.pebble.core.decoding.PebbleBytesStore;
 import org.pebble.core.decoding.iterators.Helper.Input;
 import org.pebble.core.decoding.iterators.longs.ListIterator;
 import org.pebble.core.encoding.Helper;
@@ -30,7 +29,8 @@ import org.pebble.core.encoding.OutputSuccinctStream;
 import org.pebble.core.encoding.longs.datastructures.InvertedListLongReferenceListsIndex;
 import org.pebble.core.encoding.longs.datastructures.LongReferenceListsIndex;
 import org.pebble.core.encoding.longs.datastructures.LongReferenceListsStore;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -100,8 +100,8 @@ public class LongListsTest {
             "1 1 01101 00101 0101 01100 1 01101 01101 0100 0100 01101 0101 01110 01111 01100" +
             "0100 1 1 1 1 01111 01111 1 01110 0101 0100 0101 0101 0101 0100 1"
         );
-        final long[] offsets = new long[] {0L, 64L};
-        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 64L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         final int valueBitSize = 5;
         final LongList[] expectedLists = new LongList[] {
             new LongArrayList(new long[] {12L, 8L, 5L, 12L, 13L, 5L, 13L, 8L}),

--- a/src/test/java/org/pebble/core/StrictlyIncrementalIntListsTest.java
+++ b/src/test/java/org/pebble/core/StrictlyIncrementalIntListsTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,13 +14,14 @@ package org.pebble.core;
  *  limitations under the License.
  */
 
+package org.pebble.core;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.FastIntegrationTest;
-import org.pebble.core.decoding.PebbleBytesStore;
 import org.pebble.core.decoding.iterators.Helper.Input;
 import org.pebble.core.decoding.iterators.ints.StrictlyIncrementalListIterator;
 import org.pebble.core.encoding.Helper;
@@ -31,7 +30,8 @@ import org.pebble.core.encoding.OutputSuccinctStream;
 import org.pebble.core.encoding.ints.datastructures.IntReferenceListsIndex;
 import org.pebble.core.encoding.ints.datastructures.IntReferenceListsStore;
 import org.pebble.core.encoding.ints.datastructures.InvertedListIntReferenceListsIndex;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -135,8 +135,8 @@ public class StrictlyIncrementalIntListsTest {
             "0101 1 1 1 1" +
             "01101 0101 0 0101 01100 1 1"
         );
-        final long[] offsets = new long[] {0L, 22L, 49L, 57L, 76L, 84L};
-        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 22L, 49L, 57L, 76L, 84L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         final int valueBitSize = 5;
         final IntList[] expectedLists = new IntList[] {
             new IntArrayList(new int[] {5, 8, 12, 13}),

--- a/src/test/java/org/pebble/core/StrictlyIncrementalLongListsTest.java
+++ b/src/test/java/org/pebble/core/StrictlyIncrementalLongListsTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,13 +14,14 @@ package org.pebble.core;
  *  limitations under the License.
  */
 
+package org.pebble.core;
+
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongList;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.FastIntegrationTest;
-import org.pebble.core.decoding.PebbleBytesStore;
 import org.pebble.core.decoding.iterators.Helper.Input;
 import org.pebble.core.decoding.iterators.longs.StrictlyIncrementalListIterator;
 import org.pebble.core.encoding.Helper;
@@ -31,7 +30,8 @@ import org.pebble.core.encoding.OutputSuccinctStream;
 import org.pebble.core.encoding.longs.datastructures.InvertedListLongReferenceListsIndex;
 import org.pebble.core.encoding.longs.datastructures.LongReferenceListsIndex;
 import org.pebble.core.encoding.longs.datastructures.LongReferenceListsStore;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -135,8 +135,8 @@ public class StrictlyIncrementalLongListsTest {
             "0101 1 1 1 1" +
             "01101 0101 0 0101 01100 1 1"
         );
-        final long[] offsets = new long[] {0L, 22L, 49L, 57L, 76L, 84L};
-        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 22L, 49L, 57L, 76L, 84L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         final int valueBitSize = 5;
         final LongList[] expectedLists = new LongList[] {
             new LongArrayList(new long[] {5L, 8L, 12L, 13L}),

--- a/src/test/java/org/pebble/core/decoding/PebbleBytesStoreTest.java
+++ b/src/test/java/org/pebble/core/decoding/PebbleBytesStoreTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,10 +14,13 @@ package org.pebble.core.decoding;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding;
+
 import it.unimi.dsi.io.InputBitStream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.UnitTest;
+import org.pebble.core.PebbleBytesStore;
 import org.pebble.core.decoding.iterators.Helper.Input;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/org/pebble/core/decoding/iterators/ints/BaseListIteratorHelper.java
+++ b/src/test/java/org/pebble/core/decoding/iterators/ints/BaseListIteratorHelper.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,10 +14,14 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.io.InputBitStream;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
 import org.pebble.core.encoding.DefaultParametersValues;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -44,12 +46,13 @@ public class BaseListIteratorHelper {
         }
 
         public BaseListIterator build() throws IOException {
+            final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
             return new BaseListIterator(
                 listIndex,
                 DefaultParametersValues.INT_BITS,
                 DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE,
                 input.stream,
-                new BytesArrayPebbleBytesStore(input.buffer, new long[] {0L})
+                new BytesArrayPebbleBytesStore(input.buffer, offsetsStore)
             ) {
                 @Override
                 protected ReferenceIterator initializeReferenceIterator(int listIndex, InputBitStream inputBitStream)

--- a/src/test/java/org/pebble/core/decoding/iterators/ints/IncrementalListIteratorTest.java
+++ b/src/test/java/org/pebble/core/decoding/iterators/ints/IncrementalListIteratorTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,14 +14,18 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.pebble.UnitTest;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -95,8 +97,8 @@ public class IncrementalListIteratorTest {
     private static IncrementalListIterator buildIncrementalIterator(final Helper.Input input) throws IOException {
         final int valueBitSize = 2;
         final int listIndex = 0;
-        final long[] offsets = new long[] {0L};
-        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         return IncrementalListIterator.build(listIndex, valueBitSize, bytesStore);
     }
 

--- a/src/test/java/org/pebble/core/decoding/iterators/ints/ListIteratorTest.java
+++ b/src/test/java/org/pebble/core/decoding/iterators/ints/ListIteratorTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,14 +14,18 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.pebble.UnitTest;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -92,8 +94,8 @@ public class ListIteratorTest {
     private static ListIterator buildIterator(final Helper.Input input) throws IOException {
         final int valueBitSize = 2;
         final int listIndex = 0;
-        final long[] offsets = new long[] {0};
-        PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
+        PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         return ListIterator.build(
             listIndex,
             valueBitSize,

--- a/src/test/java/org/pebble/core/decoding/iterators/ints/ReferenceIteratorTest.java
+++ b/src/test/java/org/pebble/core/decoding/iterators/ints/ReferenceIteratorTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.ints;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,6 +14,8 @@ package org.pebble.core.decoding.iterators.ints;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.ints;
+
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntList;
@@ -23,9 +23,11 @@ import it.unimi.dsi.io.InputBitStream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.UnitTest;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
 import org.pebble.core.encoding.DefaultParametersValues;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -49,12 +51,13 @@ public class ReferenceIteratorTest {
         }
 
         public ReferenceIterator build() throws IOException {
+            final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 0L});
             return new ReferenceIterator(
                 listIndex,
                 DefaultParametersValues.INT_BITS,
                 DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE,
                 input.stream,
-                new BytesArrayPebbleBytesStore(input.buffer, new long[] {0L, 0L})
+                new BytesArrayPebbleBytesStore(input.buffer, offsetsStore)
             ) {
                 @Override
                 public IntIterator getReferenceListIterator(

--- a/src/test/java/org/pebble/core/decoding/iterators/longs/BaseListIteratorHelper.java
+++ b/src/test/java/org/pebble/core/decoding/iterators/longs/BaseListIteratorHelper.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,10 +14,14 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.io.InputBitStream;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
 import org.pebble.core.encoding.DefaultParametersValues;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -44,12 +46,13 @@ public class BaseListIteratorHelper {
         }
 
         public BaseListIterator build() throws IOException {
+            final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
             return new BaseListIterator(
                 listIndex,
                 DefaultParametersValues.LONG_BITS,
                 DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE,
                 input.stream,
-                new BytesArrayPebbleBytesStore(input.buffer, new long[] {0L})
+                new BytesArrayPebbleBytesStore(input.buffer, offsetsStore)
             ) {
                 @Override
                 protected ReferenceIterator initializeReferenceIterator(int listIndex, InputBitStream inputBitStream)

--- a/src/test/java/org/pebble/core/decoding/iterators/longs/IncrementalListIteratorTest.java
+++ b/src/test/java/org/pebble/core/decoding/iterators/longs/IncrementalListIteratorTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,14 +14,18 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.pebble.UnitTest;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -95,8 +97,8 @@ public class IncrementalListIteratorTest {
     private static IncrementalListIterator buildIncrementalIterator(final Helper.Input input) throws IOException {
         final int valueBitSize = 2;
         final int listIndex = 0;
-        final long[] offsets = new long[] {0L};
-        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         return IncrementalListIterator.build(listIndex, valueBitSize, bytesStore);
     }
 

--- a/src/test/java/org/pebble/core/decoding/iterators/longs/ListIteratorTest.java
+++ b/src/test/java/org/pebble/core/decoding/iterators/longs/ListIteratorTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,14 +14,18 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.ExpectedException;
 import org.pebble.UnitTest;
-import org.pebble.core.decoding.PebbleBytesStore;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -92,8 +94,8 @@ public class ListIteratorTest {
     private static ListIterator buildIterator(final Helper.Input input) throws IOException {
         final int valueBitSize = 2;
         final int listIndex = 0;
-        final long[] offsets = new long[] {0};
-        PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
+        PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
         return ListIterator.build(
             listIndex,
             valueBitSize,

--- a/src/test/java/org/pebble/core/decoding/iterators/longs/ReferenceIteratorTest.java
+++ b/src/test/java/org/pebble/core/decoding/iterators/longs/ReferenceIteratorTest.java
@@ -1,5 +1,3 @@
-package org.pebble.core.decoding.iterators.longs;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,6 +14,8 @@ package org.pebble.core.decoding.iterators.longs;
  *  limitations under the License.
  */
 
+package org.pebble.core.decoding.iterators.longs;
+
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongList;
@@ -23,9 +23,11 @@ import it.unimi.dsi.io.InputBitStream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.UnitTest;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
 import org.pebble.core.encoding.DefaultParametersValues;
-import org.pebble.utils.decoding.BytesArrayPebbleBytesStore;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
 
 import java.io.IOException;
 
@@ -49,12 +51,13 @@ public class ReferenceIteratorTest {
         }
 
         public ReferenceIterator build() throws IOException {
+            final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 0L});
             return new ReferenceIterator(
                 listIndex,
                 DefaultParametersValues.LONG_BITS,
                 DefaultParametersValues.DEFAULT_MIN_INTERVAL_SIZE,
                 input.stream,
-                new BytesArrayPebbleBytesStore(input.buffer, new long[] {0L, 0L})
+                new BytesArrayPebbleBytesStore(input.buffer, offsetsStore)
             ) {
                 @Override
                 public LongIterator getReferenceListIterator(

--- a/src/test/java/org/pebble/core/encoding/EncodingInfoTest.java
+++ b/src/test/java/org/pebble/core/encoding/EncodingInfoTest.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.core.encoding;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(UnitTest.class)
+public class EncodingInfoTest {
+
+    @Test
+    public void incrementCurrentIndexItShouldIncrementCurrentIndexValueInOneAndReturnPreviousValue() {
+        final EncodingInfo encodingInfo = new EncodingInfo();
+
+        assertEquals(0, encodingInfo.incrementCurrentIndex());
+        assertEquals(1, encodingInfo.getCurrentIndex());
+    }
+
+    @Test
+    public void incrementOffsetItShouldIncrementOffsetInGivenValueAndShouldReturnIncrementedValue() {
+        final int deltaOffset = 5;
+        final EncodingInfo encodingInfo = new EncodingInfo();
+
+        assertEquals(deltaOffset, encodingInfo.incrementOffset(deltaOffset));
+        assertEquals(deltaOffset, encodingInfo.getOffset());
+    }
+
+    @Test
+    public void saveItShouldSaveExpectedInformation() {
+        final int expectedTotalElements = 1;
+        final long expectedTotalSize = 2L;
+        final String expectedOutput = String.format(
+            "totalElements: %d\ntotalSize: %d\n",
+            expectedTotalElements,
+            expectedTotalSize
+        );
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        encodingInfo.incrementCurrentIndex();
+        encodingInfo.incrementOffset((int)expectedTotalSize);
+
+        encodingInfo.save(outputStream);
+
+        assertEquals(expectedOutput, outputStream.toString());
+    }
+
+    @Test
+    public void loadItShouldLoadExpectedInformation() throws IOException {
+        final int expectedTotalElements = 1;
+        final long expectedTotalSize = 2L;
+        final InputStream inputStream = new ByteArrayInputStream(String.format(
+            "totalElements: %d\ntotalSize: %d\n",
+            expectedTotalElements,
+            expectedTotalSize
+        ).getBytes());
+
+        final EncodingInfo encodingInfo = EncodingInfo.load(inputStream);
+
+        assertEquals(expectedTotalElements, encodingInfo.getCurrentIndex());
+        assertEquals(expectedTotalSize, encodingInfo.getOffset());
+    }
+
+}

--- a/src/test/java/org/pebble/types/TypeIntDecoderTypeIteratorTest.java
+++ b/src/test/java/org/pebble/types/TypeIntDecoderTypeIteratorTest.java
@@ -1,0 +1,80 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.pebble.UnitTest;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category(UnitTest.class)
+public class TypeIntDecoderTypeIteratorTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void itShouldThrowUnsupportedOperationExceptionWhenCallingRemove() throws IOException {
+        expectedException.expect(UnsupportedOperationException.class);
+        expectedException.expectMessage("List is immutable");
+        Iterator iterator = build().read(0, 0);
+
+        iterator.remove();
+    }
+
+    @Test
+    public void itShouldReturnFalseWhenCallingHasNextAndThereIsNoRemainingElements() throws IOException {
+        Iterator iterator = build(new IntArrayList()).read(0, 0);
+
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void itShouldReturnTrueWhenCallingHasNextAndThereIsRemainingElements() throws IOException {
+        Iterator iterator = build(new IntArrayList(new int[]{1})).read(0, 0);
+
+        assertTrue(iterator.hasNext());
+    }
+
+    private static TypeIntDecoder build() {
+        return build(null);
+    }
+
+    private static TypeIntDecoder build(final IntList list) {
+        return new TypeIntDecoder(null) {
+            @Override
+            public Iterator read(int listIndex, int valueBitSize) throws IOException {
+                return new TypeIterator(list == null ? null : list.iterator()) {
+                    @Override
+                    public Object next() {
+                        return iterator.next();
+                    }
+                };
+            }
+        };
+    }
+
+}

--- a/src/test/java/org/pebble/types/TypeIntEncoderTest.java
+++ b/src/test/java/org/pebble/types/TypeIntEncoderTest.java
@@ -1,0 +1,60 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(UnitTest.class)
+public class TypeIntEncoderTest {
+
+    @Test
+    public void setIntListItShouldSetExpectedEncodedValuesList() throws IOException {
+        TypeIntEncoder encoder = new TypeIntEncoder() {
+            @Override
+            protected int encode(Object element) throws IOException {
+                return element.hashCode();
+            }
+        };
+        List values = new ArrayList(Arrays.asList(new Object[]{
+            new Object(),
+            new Object(),
+            new Object()
+        }));
+        final IntList listBuffer = new IntArrayList();
+        final IntList expectedListBuffer = new IntArrayList(new int[] {
+            values.get(0).hashCode(),
+            values.get(1).hashCode(),
+            values.get(2).hashCode()
+        });
+
+        encoder.setIntList(values, listBuffer);
+
+        assertEquals(expectedListBuffer, listBuffer);
+    }
+
+}

--- a/src/test/java/org/pebble/types/TypeMapDecoderTest.java
+++ b/src/test/java/org/pebble/types/TypeMapDecoderTest.java
@@ -1,0 +1,91 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types;
+
+import it.unimi.dsi.io.InputBitStream;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
+import org.pebble.core.decoding.iterators.Helper;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.pebble.core.decoding.iterators.Helper.getInput;
+
+@Category(UnitTest.class)
+public class TypeMapDecoderTest {
+
+    @Test
+    public void readItShouldReturnIteratorContainingExpectedEncodedValue() throws IOException {
+        final List<String> expectedDecodedValues = new ArrayList<String>();
+        expectedDecodedValues.add("a");
+        expectedDecodedValues.add("b");
+        expectedDecodedValues.add("a");
+        expectedDecodedValues.add("a");
+        expectedDecodedValues.add("a");
+        expectedDecodedValues.add("b");
+        expectedDecodedValues.add("b");
+        expectedDecodedValues.add("a");
+        /**
+         * list=["a", "b", "a", "a", "a", "b", "b", "a"]
+         * mapping={"a": 0, "b": 1}
+         * mapped_list=[0, 1, 0, 0, 0, 1, 1, 0]
+         * values=[0, 1] indexes=[0, 1, 0, 0, 0, 1, 1, 0]
+         * reference=[0], intervals=[0], delta=[2, 0, 0],   indexes=[6, 0, 2, 1, 0, 0, 2, 0, 1]
+         * 1              1              11   00000 1       111   1 11   10   1 1 11   1 10
+         * 1              1              2-1  00000 1       3-11  1 2-1  2-0  1 1 2-1  1 2-0
+         * 1              1              10-1 00000 1       11-11 1 10-1 10-0 1 1 10-1 1 10-0
+         * 1              1              0101 00000 1       01111 1 0101 0100 1 1 0101 1 0100
+         */
+        final Helper.Input input = getInput(
+            "01100001" +
+            "01100010" +
+            "1 1 0101 00000 1 01111 1 0101 0100 1 1 0101 1 0100"
+        );
+        final TypeMapDecoder<String> decoder = build(input, new long[] {0L, 8L, 16L});
+        final List<String> decodedValues = new ArrayList<String>();
+        final int listIndex = 2;
+        final int valueBitSize = 5;
+
+        final Iterator<String> iterator = decoder.read(listIndex, valueBitSize);
+        while(iterator.hasNext()) {
+            decodedValues.add(iterator.next());
+        }
+
+        assertEquals(expectedDecodedValues, decodedValues);
+    }
+
+    private static TypeMapDecoder<String> build(final Helper.Input input, final long[] offsets) {
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(offsets);
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
+        return new TypeMapDecoder<String>(bytesStore) {
+            @Override
+            protected String read(InputBitStream inputBitStream) throws IOException {
+                return ((char) inputBitStream.readInt(8)) + "";
+            }
+        };
+    }
+
+}

--- a/src/test/java/org/pebble/types/TypeMapEncoderTest.java
+++ b/src/test/java/org/pebble/types/TypeMapEncoderTest.java
@@ -1,0 +1,129 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types;
+
+import it.unimi.dsi.io.OutputBitStream;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+import org.pebble.core.PebbleOffsetsStoreWriter;
+import org.pebble.core.encoding.EncodingInfo;
+import org.pebble.utils.LongListPebbleOffsetsStore;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(UnitTest.class)
+public class TypeMapEncoderTest {
+
+    @Test
+    public void whenValueIsMissingFromMapEncodeItShouldReturnNewIndex() throws IOException {
+        final TypeMapEncoder encoder = build();
+        final Object element = new Object();
+
+        assertEquals(0, encoder.encode(element));
+    }
+
+    @Test
+    public void whenValueAlreadyExistsInMapEncodeItShouldReturnExistingIndex() throws IOException {
+        final TypeMapEncoder encoder = build();
+        final Object element = new Object();
+        encoder.encode(element);
+
+        assertEquals(0, encoder.encode(element));
+    }
+
+    @Test
+    public void whenValueAlreadyExistsInMapButReferenceIsBiggerThanReferenceWindowSizeEncodeItShouldReturnNewIndex()
+        throws IOException
+    {
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        final TypeMapEncoder encoder = build(encodingInfo);
+        final Object element = new Object();
+        encoder.encode(element);
+        encodingInfo.incrementCurrentIndex();
+        encodingInfo.incrementCurrentIndex();
+        encodingInfo.incrementCurrentIndex();
+
+        assertEquals(4, encoder.encode(element));
+    }
+
+    @Test
+    public void whenMapIsFullAndValueIsMissingFromMapEncodeItShouldReturnNewIndex() throws IOException {
+        final TypeMapEncoder encoder = build();
+        final Object element = new Object();
+        encoder.encode(new Object());
+        encoder.encode(new Object());
+
+        assertEquals(2, encoder.encode(element));
+    }
+
+    @Test
+    public void whenMapIsFullAndValueToBeRemovedWasAssignedNewerIndexAndValueIsMissingEncodeItShouldReturnNewIndex()
+        throws IOException
+    {
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        final TypeMapEncoder encoder = build(encodingInfo);
+        final Object previousElement = new Object();
+        final Object element = new Object();
+        encoder.encode(previousElement);
+        encodingInfo.incrementCurrentIndex();
+        encodingInfo.incrementCurrentIndex();
+        encoder.encode(previousElement);
+
+        assertEquals(4, encoder.encode(element));
+    }
+
+    @Test
+    public void whenValueToBeReplacedInTheBufferHasBeenAlreadyRemovedFromMapAndValueIsMissingEncodeItShouldReturnNewIndex()
+        throws IOException
+    {
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        final TypeMapEncoder encoder = build(encodingInfo);
+        final Object previousElement = new Object();
+        final Object element = new Object();
+        encoder.encode(previousElement);
+        encodingInfo.incrementCurrentIndex();
+        encodingInfo.incrementCurrentIndex();
+        encoder.encode(previousElement);
+        encodingInfo.incrementCurrentIndex();
+        encodingInfo.incrementCurrentIndex();
+        encoder.encode(new Object());
+
+        assertEquals(7, encoder.encode(element));
+    }
+
+    private static TypeMapEncoder build() {
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        return build(encodingInfo);
+    }
+
+    private static TypeMapEncoder build(final EncodingInfo encodingInfo) {
+        final int referenceWindowSize = 2;
+        final byte[] buffer = new byte[0];
+        final OutputBitStream outputBitStream = new OutputBitStream(buffer);
+        final PebbleOffsetsStoreWriter offsetsStore = new LongListPebbleOffsetsStore();
+        return new TypeMapEncoder(referenceWindowSize, outputBitStream, offsetsStore, encodingInfo) {
+            @Override
+            public int write(Object element) throws IOException {
+                return 1;
+            }
+        };
+    }
+
+}

--- a/src/test/java/org/pebble/types/text/TextIntDecoderTest.java
+++ b/src/test/java/org/pebble/types/text/TextIntDecoderTest.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.text;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
+import org.pebble.core.decoding.iterators.Helper;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.pebble.core.decoding.iterators.Helper.getInput;
+
+@Category(UnitTest.class)
+public class TextIntDecoderTest {
+
+    @Test
+    public void encodeItShouldReturnExpectedDecodedValue() throws IOException {
+        final Helper.Input input = getInput(
+            "00100000 01000101 01011000 01000001 01001101 01010000 01001100 01000101"
+        );
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
+        final TextIntDecoder encoder = new TextIntDecoder(bytesStore);
+        final String expectedValue = "EXAMPLE";
+
+        final String value = encoder.read(input.stream);
+
+        assertEquals(expectedValue, value);
+    }
+
+}

--- a/src/test/java/org/pebble/types/text/TextIntEncoderTest.java
+++ b/src/test/java/org/pebble/types/text/TextIntEncoderTest.java
@@ -1,0 +1,101 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.text;
+
+import it.unimi.dsi.io.OutputBitStream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+import org.pebble.UnitTest;
+import org.pebble.core.PebbleOffsetsStoreWriter;
+import org.pebble.core.encoding.EncodingInfo;
+import org.pebble.core.encoding.Helper;
+import org.pebble.utils.LongListPebbleOffsetsStore;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.pebble.core.encoding.Helper.getOutput;
+import static org.pebble.core.encoding.Helper.toBinaryString;
+
+@Category(UnitTest.class)
+public class TextIntEncoderTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void encodeItShouldReturnExpectedEncodedValue() throws IOException {
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        final int referenceWindowSize = 2;
+        final Helper.Output out = getOutput();
+        final OutputBitStream outputBitStream = new OutputBitStream(out.buffer);
+        final PebbleOffsetsStoreWriter offsetsStore = new LongListPebbleOffsetsStore();
+        final TextIntEncoder encoder = new TextIntEncoder(
+            referenceWindowSize,
+            outputBitStream,
+            offsetsStore,
+            encodingInfo
+        );
+        final String value = "EXAMPLE";
+        /**
+         * 7        E         X       A        M        P        L        E
+         * 1000     01000101 01011000 01000001 01001101 01010000 01001100 01000101
+         * 100-000  01000101 01011000 01000001 01001101 01010000 01001100 01000101
+         * 00100000 01000101 01011000 01000001 01001101 01010000 01001100 01000101
+         */
+        final String expectedOutput = (
+            "00100000 01000101 01011000 01000001 01001101 01010000 01001100 01000101"
+        ).replace(" ", "");
+        final int expectedTotalOffset = 64;
+
+        final int totalOffset = encoder.write(value);
+
+        assertEquals(expectedOutput, toBinaryString(out.buffer, totalOffset));
+        assertEquals(expectedTotalOffset, totalOffset);
+    }
+
+    @Test
+    public void x() throws IOException {
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        final int referenceWindowSize = 2;
+        final Helper.Output out = getOutput();
+        final OutputBitStream outputBitStream = new OutputBitStream(out.buffer);
+        final PebbleOffsetsStoreWriter offsetsStore = new LongListPebbleOffsetsStore();
+        final TextIntEncoder encoder = new TextIntEncoder(
+            referenceWindowSize,
+            outputBitStream,
+            offsetsStore,
+            encodingInfo
+        );
+        final StringBuilder value = new StringBuilder();
+        for (int i = 0; i <= TextIntEncoder.MAX_TEXT_LENGTH; i++) {
+            value.append('a');
+        }
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage(String.format(
+            "element \"%s\" of length: %d, cannot be bigger than %d",
+            value,
+            value.length(),
+            TextIntEncoder.MAX_TEXT_LENGTH
+        ));
+
+        encoder.write(value.toString());
+    }
+
+}

--- a/src/test/java/org/pebble/types/timestamp/TimestampIntDecoderTest.java
+++ b/src/test/java/org/pebble/types/timestamp/TimestampIntDecoderTest.java
@@ -1,0 +1,75 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.timestamp;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
+import org.pebble.core.decoding.iterators.Helper;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.pebble.core.decoding.iterators.Helper.getInput;
+
+@Category(UnitTest.class)
+public class TimestampIntDecoderTest {
+
+    @Test
+    public void readItShouldReturnIteratorContainingExpectedDecodedValues() throws IOException {
+        final List<Timestamp> expectedTimestamps = new ArrayList<Timestamp>();
+        expectedTimestamps.add(Timestamp.valueOf("2015-04-29 18:09:34"));
+        expectedTimestamps.add(Timestamp.valueOf("2015-04-29 18:09:39"));
+        expectedTimestamps.add(Timestamp.valueOf("2015-04-29 18:09:41"));
+        /**
+         * list=["Wed Apr 29 18:09:34 -0700 2015", "Wed Apr 29 18:09:39 -0700 2015", "Wed Apr 29 18:09:41 -0700 2015"]
+         * mapping={
+         *   "Wed Apr 29 18:09:34 -0700 2015": 1430356174,
+         *   "Wed Apr 29 18:09:39 -0700 2015": 1430356179,
+         *   "Wed Apr 29 18:09:41 -0700 2015": 1430356181
+         * }
+         * mapped_list=[1430356174, 1430356179, 1430356181]
+         * values=[1430356174, 1430356179, 1430356181] indexes=[0, 1, 2]
+         * reference=[0], intervals=[0], delta=[3, 1430356174, 4, 1],                           indexes=[0, 0, 2, 2]
+         * 1              1                    100   1010101010000011000000011001110 101   10   1 1 11   11
+         * 1              1                    3-00  1010101010000011000000011001110 3-01  2-0  1 1 2-1  2-1
+         * 1              1                    11-00 1010101010000011000000011001110 11-01 10-0 1 1 10-1 10-1
+         * 1              1                    01100 1010101010000011000000011001110 01101 0100 1 1 0101 0101
+         */
+        final Helper.Input input = getInput("1 1 01100 1010101010000011000000011001110 01101 0100 1 1 0101 0101");
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
+        final TimestampIntDecoder decoder = new TimestampIntDecoder(bytesStore);
+
+        final Iterator<Timestamp> iterator = decoder.read(0, 31);
+
+        final List<Timestamp> timestamps = new ArrayList<Timestamp>();
+        while (iterator.hasNext()) {
+            timestamps.add(iterator.next());
+        }
+        assertEquals(expectedTimestamps, timestamps);
+    }
+
+}

--- a/src/test/java/org/pebble/types/timestamp/TimestampIntEncoderTest.java
+++ b/src/test/java/org/pebble/types/timestamp/TimestampIntEncoderTest.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.timestamp;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(UnitTest.class)
+public class TimestampIntEncoderTest {
+
+    @Test
+    public void encodeItShouldReturnExpectedEncodedValue() throws IOException {
+        final TimestampIntEncoder encoder = new TimestampIntEncoder();
+        final Timestamp value = new Timestamp(1426034806966l);
+        final int expectedEncodedValue = 1426034806;
+
+        assertEquals(expectedEncodedValue, encoder.encode(value));
+    }
+
+}

--- a/src/test/java/org/pebble/types/uuid/UUIDIntDecoderTest.java
+++ b/src/test/java/org/pebble/types/uuid/UUIDIntDecoderTest.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.uuid;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+import org.pebble.core.PebbleBytesStore;
+import org.pebble.core.PebbleOffsetsStore;
+import org.pebble.core.decoding.iterators.Helper;
+import org.pebble.utils.BytesArrayPebbleBytesStore;
+import org.pebble.utils.LongListPebbleOffsetsStore;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.pebble.core.decoding.iterators.Helper.getInput;
+
+@Category(UnitTest.class)
+public class UUIDIntDecoderTest {
+
+    @Test
+    public void encodeItShouldReturnExpectedDecodedValue() throws IOException {
+        final Helper.Input input = getInput(
+            "1011101111100110111111001000000110000010010111100100100010011001" +
+            "1011101010011111100001100000110011101100111010111100101111011110"
+        );
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L});
+        final PebbleBytesStore bytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
+        final UUIDIntDecoder encoder = new UUIDIntDecoder(bytesStore);
+        final UUID expectedValue = UUID.fromString("bbe6fc81-825e-4899-ba9f-860cecebcbde");
+
+        final UUID value = encoder.read(input.stream);
+
+        assertEquals(expectedValue, value);
+    }
+
+}

--- a/src/test/java/org/pebble/types/uuid/UUIDIntEncoderTest.java
+++ b/src/test/java/org/pebble/types/uuid/UUIDIntEncoderTest.java
@@ -1,0 +1,69 @@
+/**
+ *  Copyright 2015 Groupon
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.pebble.types.uuid;
+
+import it.unimi.dsi.io.OutputBitStream;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.pebble.UnitTest;
+import org.pebble.core.PebbleOffsetsStoreWriter;
+import org.pebble.core.encoding.EncodingInfo;
+import org.pebble.core.encoding.Helper;
+import org.pebble.utils.LongListPebbleOffsetsStore;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.pebble.core.encoding.Helper.getOutput;
+import static org.pebble.core.encoding.Helper.toBinaryString;
+
+@Category(UnitTest.class)
+public class UUIDIntEncoderTest {
+
+    @Test
+    public void encodeItShouldReturnExpectedEncodedValue() throws IOException {
+        final EncodingInfo encodingInfo = new EncodingInfo();
+        final int referenceWindowSize = 2;
+        final Helper.Output out = getOutput();
+        final OutputBitStream outputBitStream = new OutputBitStream(out.buffer);
+        final PebbleOffsetsStoreWriter offsetsStore = new LongListPebbleOffsetsStore();
+        final UUIDIntEncoder encoder = new UUIDIntEncoder(
+            referenceWindowSize,
+            outputBitStream,
+            offsetsStore,
+            encodingInfo
+        );
+        final UUID value = UUID.fromString("bbe6fc81-825e-4899-ba9f-860cecebcbde");
+        /**
+         * "bbe6fc81-825e-4899-ba9f-860cecebcbde"
+         * -4999129671285355554 --> 1011101111100110111111001000000110000010010111100100100010011001
+         * -4999129671285355554 --> 1011101010011111100001100000110011101100111010111100101111011110
+         */
+        final String expectedOutput = (
+            "1011101111100110111111001000000110000010010111100100100010011001" +
+            "1011101010011111100001100000110011101100111010111100101111011110"
+        ).replace(" ", "");
+        final int expectedTotalOffset = 128;
+
+        final int totalOffset = encoder.write(value);
+
+        assertEquals(expectedOutput, toBinaryString(out.buffer, totalOffset));
+        assertEquals(expectedTotalOffset, totalOffset);
+    }
+
+}

--- a/src/test/java/org/pebble/utils/BytesArrayPebbleBytesStoreTest.java
+++ b/src/test/java/org/pebble/utils/BytesArrayPebbleBytesStoreTest.java
@@ -1,5 +1,3 @@
-package org.pebble.utils.decoding;
-
 /**
  *  Copyright 2015 Groupon
  *
@@ -16,9 +14,12 @@ package org.pebble.utils.decoding;
  *  limitations under the License.
  */
 
+package org.pebble.utils;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.pebble.UnitTest;
+import org.pebble.core.PebbleOffsetsStore;
 import org.pebble.core.decoding.iterators.Helper;
 
 import java.io.IOException;
@@ -36,8 +37,8 @@ public class BytesArrayPebbleBytesStoreTest {
             "1 1 01101 00101 0101 01100 1 01101 01101 0100 0100 01101 0101 01110 01111 01100" +
             "0100 1 1 1 1 01111 01111 1 01110 0101 0100 0101 0101 0101 0100 1"
         );
-        final long[] offsets = {0L, 64L};
-        final BytesArrayPebbleBytesStore pebbleBytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 64L});
+        final BytesArrayPebbleBytesStore pebbleBytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
 
         assertSame(pebbleBytesStore.get(0), input.buffer);
     }
@@ -48,8 +49,8 @@ public class BytesArrayPebbleBytesStoreTest {
             "1 1 01101 00101 0101 01100 1 01101 01101 0100 0100 01101 0101 01110 01111 01100" +
             "0100 1 1 1 1 01111 01111 1 01110 0101 0100 0101 0101 0101 0100 1"
         );
-        final long[] offsets = {0L, 64L};
-        final BytesArrayPebbleBytesStore pebbleBytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsets);
+        final PebbleOffsetsStore offsetsStore = new LongListPebbleOffsetsStore(new long[] {0L, 64L});
+        final BytesArrayPebbleBytesStore pebbleBytesStore = new BytesArrayPebbleBytesStore(input.buffer, offsetsStore);
 
         assertEquals(64L, pebbleBytesStore.offset(1));
     }


### PR DESCRIPTION
* Timestamp with seconds precision.
* UUID
* Text. This is intended for an small set of possible values, such
  as labels, categories, etc.

Refactor base offsets store, so its implementing classes can have
cleaner implementations.

CR=harroyo